### PR TITLE
Alterada a funcao cutin para uso diretamente no personagem

### DIFF
--- a/npc/custom/rankingIcon.txt
+++ b/npc/custom/rankingIcon.txt
@@ -1,0 +1,27 @@
+//===== rAthena Script ======================================= 
+prontera,0,0,0	script	SetRankingIcon	-1,{
+	
+
+OnInit: 
+	startnpctimer;
+end;    
+
+
+OnTimer1: 
+	function rankingIcon;
+	rankingIcon("rank1",1);
+	setnpctimer 0;
+end; 
+
+function	rankingIcon	{
+	freeloop(true);
+	.@filename$ = getarg(0);
+	.@position = getarg(1);
+	.@s = getunits(BL_PC,.@SD);
+	for(.@i=0;.@i<.@s;.@i++){
+		if((.@cid = convertpcinfo(.@SD[.@i],CPC_CHAR)))
+			cutin(.@filename$,.@position,.@cid);
+	}
+	return;
+}
+}

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -6889,7 +6889,7 @@ BUILDIN_FUNC(cutin)
 {
 	TBL_PC* sd;
 
-	if( !script_rid2sd(sd) )
+	if(!script_charid2sd(4, sd))
 		return SCRIPT_CMD_SUCCESS;
 
 	clif_cutin(sd,script_getstr(st,2),script_getnum(st,3));
@@ -27032,7 +27032,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(delitemidx,"i??"),
 	BUILDIN_DEF2(enableitemuse,"enable_items",""),
 	BUILDIN_DEF2(disableitemuse,"disable_items",""),
-	BUILDIN_DEF(cutin,"si"),
+	BUILDIN_DEF(cutin,"si?"),
 	BUILDIN_DEF(viewpoint,"iiiii?"),
 	BUILDIN_DEF(viewpointmap, "siiiii"),
 	BUILDIN_DEF(heal,"ii?"),


### PR DESCRIPTION
Alterado o metodo cutin para que ele possa ser utilizado diretamente no personagem, assim permitindo varios usos possiveis, tal como o script de exemplo que atribui um icone permanente no centro da tela. 
(Depende da imagem existir dentro da pasta `data\texture\À¯ÀúÀÎÅÍÆäÀÌ½º\illust`  e estar nas dimensões e posicionamentos corretos)

Exemplo:
![image](https://github.com/RagnaSplash/ProjetoRO/assets/80433669/684592f4-ac35-4ff3-ae08-5e1ccc1ac311)
